### PR TITLE
Fixed camera access in skypeforlinux (Ubuntu 16.04.3 LTS)

### DIFF
--- a/usr.share.skypeforlinux.skypeforlinux
+++ b/usr.share.skypeforlinux.skypeforlinux
@@ -34,7 +34,7 @@
   /dev/dri/ r,
   /dev/video* rwm,
   /dev/snd/* rwm,
-  owner /dev/shm/** rwm,
+  owner /dev/shm/** rwml,
 
   @{PROC} r,
   @{PROC}/version r,

--- a/usr.share.skypeforlinux.skypeforlinux
+++ b/usr.share.skypeforlinux.skypeforlinux
@@ -49,8 +49,10 @@
 
   /usr/share/themes** r,
   /usr/share/fonts** rm,
+  /usr/share/locale-langpack/** rm,
 
   owner @{HOME}/.config/skypeforlinux** rwkm,
+  owner @{HOME}/.config/gtkrc-2.0 r,
   owner @{HOME}/.gtkrc-2.0 r,
   owner @{HOME}/.icons** r,
   owner @{HOME}/.config/autostart/skypeforlinux.desktop rw,


### PR DESCRIPTION
I have made a minor change to fix the camera under Ubuntu 16.04.3 LTS by adding "l" mode to /dev/shm/**.